### PR TITLE
Adding check adb accessibility on device

### DIFF
--- a/multidevice/main.py
+++ b/multidevice/main.py
@@ -183,8 +183,8 @@ class Window(QtWidgets.QWidget):
     def startAdb(self):
         try:
             adbClient()
-        except Exception:
-            self.scrollLayout.addWidget(InfoBox(self.scrollWidget, 'ADB не может быть запущен'))
+        except Exception as e:
+            self.scrollLayout.addWidget(InfoBox(self.scrollWidget, f'Возникла ошибка при запуске ADB\n{e}'))
 
     def getPath(self):
         return self.fileDrop.text()

--- a/multidevice/utils.py
+++ b/multidevice/utils.py
@@ -1,4 +1,4 @@
-import os
+from subprocess import PIPE, run
 import re
 
 from ppadb.client import Client as AdbClient
@@ -6,10 +6,15 @@ from ppadb.client import Client as AdbClient
 client = AdbClient(host="127.0.0.1", port=5037)
 
 
+def runAdb():
+    adb_start = run("adb devices", stdout=PIPE, stderr=PIPE, shell=True)
+    return True if adb_start.returncode == 0 else False
+
+
 def resendAdb():
     global client
-    os.system("adb devices")
-    client = AdbClient(host="127.0.0.1", port=5037)
+    if runAdb():
+        client = AdbClient(host="127.0.0.1", port=5037)
     return client
 
 
@@ -18,9 +23,11 @@ def adbClient():
     try:
         client.version()
         return client
-    except Exception:
-        os.system("adb devices")
-        resendAdb()
+    except Exception as e:
+        if runAdb():
+            resendAdb()
+        else:
+            raise Exception(f"Не удалось запустить ADB командой adb devices\n{e}")
         return client
 
 


### PR DESCRIPTION
Reffered to https://github.com/DaniilSmirnov/APKInstaller/issues/18 and https://github.com/DaniilSmirnov/APKInstaller/issues/17 this fix should improve UX by adding an visual error box informing about it

Moving from `os.system` to `subprocess.run` allows to get return code and be sure that adb is running

Code styling like CamelCase namings and other stuff are tried to keeped in consistency :)